### PR TITLE
Add `sass` syntax to csscomb.coffee

### DIFF
--- a/lib/csscomb.coffee
+++ b/lib/csscomb.coffee
@@ -29,7 +29,7 @@ findConfig = ->
       "csscomb"
 
 syntaxes =
-  supported: ['css', 'scss', 'less']
+  supported: ['css', 'sass', 'scss', 'less']
   default: 'css'
 
 csscomb = (editor) ->


### PR DESCRIPTION
csscomb supports the sass syntax for quite a while now: https://twitter.com/csscomb/status/491128538238844929

[Original commit in the csscomb repo](https://github.com/csscomb/csscomb.js/commit/0fca0f8ff2568a48a0a40da73af4498426df808a)