### PR TITLE
Updating dependencies, `processString` syntax fix and tidy up

### DIFF
--- a/lib/csscomb.coffee
+++ b/lib/csscomb.coffee
@@ -41,5 +41,5 @@ csscomb = (editor) ->
   ranges.forEach (range) ->
     content = editor.getTextInBufferRange(range)
     comb = new Comb(config)
-    result = comb.processString(content, syntax)
+    result = comb.processString content, syntax: syntax
     editor.setTextInBufferRange(range, result)

--- a/lib/csscomb.coffee
+++ b/lib/csscomb.coffee
@@ -1,45 +1,49 @@
 CsscombRangeFinder = require './csscomb-range-finder'
-Comb = require "csscomb"
-fs = require "fs"
-CSON = require "season"
+Comb = require 'csscomb'
+fs = require 'fs'
+CSON = require 'season'
 
 module.exports =
-
   activate: (state) ->
     atom.workspaceView.command 'csscomb:run', '.editor', ->
-      editor = atom.workspaceView.getActivePaneItem()
-      csscomb(editor)
+      csscomb atom.workspaceView.getActivePaneItem()
 
 findConfig = ->
-  userConfig = atom.config.get('csscomb')
+  userConfig = atom.config.get 'csscomb'
   if userConfig
-    console.log "Found user CSScomb config:", userConfig
+    console.log 'Found user CSScomb config:', userConfig
     userConfig
   else
-    jsonConfig = atom.project.resolve(".csscomb.json")
-    csonConfig = atom.project.resolve(".csscomb.cson")
-    if fs.existsSync(jsonConfig)
-      console.log "Found project CSScomb config:", jsonConfig
+    jsonConfig = atom.project.resolve '.csscomb.json'
+    csonConfig = atom.project.resolve '.csscomb.cson'
+    if fs.existsSync jsonConfig
+      console.log 'Found project CSScomb config:', jsonConfig
       require jsonConfig
-    else if fs.existsSync(csonConfig)
-      console.log "Found project CSScomb config:", csonConfig
-      CSON.readFileSync(csonConfig)
+    else if fs.existsSync csonConfig
+      console.log 'Found project CSScomb config:', csonConfig
+      CSON.readFileSync csonConfig
     else
-      console.log "Could not find project CSScomb config, using default: 'csscomb'"
-      "csscomb"
+      console.log 'Could not find project CSScomb config, using default: \'csscomb\''
+      'csscomb'
 
 syntaxes =
-  supported: ['css', 'sass', 'scss', 'less']
+  supported: [
+    'css'
+    'sass'
+    'scss'
+    'less'
+  ]
   default: 'css'
 
 csscomb = (editor) ->
-  ranges = CsscombRangeFinder.rangesFor(editor)
-  syntax = editor.getTitle()?.split('.').pop()
-  unless syntax in syntaxes.supported
-    syntax = syntaxes.default
+  ranges = CsscombRangeFinder.rangesFor editor
+  title = editor.getTitle()
+  throw new Error 'No editor selected' unless title?
+  syntax = (editor.getTitle().split '.').pop()
+  syntax = syntaxes.default unless syntax in syntaxes.supported
   config = findConfig()
   ranges.forEach (range) ->
-    content = editor.getTextInBufferRange(range)
-    comb = new Comb(config)
+    content = editor.getTextInBufferRange range
+    comb = new Comb config
     result = comb.processString content, syntax: syntax
-    editor.setTextInBufferRange(range, result)
+    editor.setTextInBufferRange range, result

--- a/lib/csscomb.coffee
+++ b/lib/csscomb.coffee
@@ -42,8 +42,8 @@ csscomb = (editor) ->
   syntax = (editor.getTitle().split '.').pop()
   syntax = syntaxes.default unless syntax in syntaxes.supported
   config = findConfig()
+  comb = new Comb config
   ranges.forEach (range) ->
     content = editor.getTextInBufferRange range
-    comb = new Comb config
     result = comb.processString content, syntax: syntax
     editor.setTextInBufferRange range, result

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "csscomb": "~2.0.4",
+    "csscomb": "~3.0.0",
     "season": "~1.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "csscomb": "~3.0.0",
-    "season": "~1.0.2"
+    "csscomb": "~3.0.4",
+    "season": "~4.0.0"
   }
 }


### PR DESCRIPTION
- Pulled https://github.com/bruce/atom-csscomb/pull/11 (Update CSScomb to [latest] version 3.0.0)
- Pulled https://github.com/bruce/atom-csscomb/pull/13 (Add `sass` syntax to csscomb.coffee)
- Updated dependencies to the latest version, including `csscomb` to latest `v3.0.4`
- Updated `processString` syntax options API according to newrst version, fixes https://github.com/bruce/atom-csscomb/issues/6 (Doesn't work on less files)
- Code formatting and tidy up
- Using one `Comb` instance for each editor range to save memory