### PR TITLE
updating to new atom selector api

### DIFF
--- a/keymaps/csscomb.cson
+++ b/keymaps/csscomb.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'atom-workspace':
   'ctrl-alt-c': 'csscomb:run'


### PR DESCRIPTION
Use the `atom-workspace` tag instead of the `workspace` class.